### PR TITLE
fix list formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This sample explains how to manage your
 using the Azure Ruby SDK.
 
 **On this page**
+
 - [Run this sample](#run)
 - [What is example.rb doing?](#example)
     - [List resource groups](#list-groups)


### PR DESCRIPTION
On azure.microsoft.com/en-us/documentation, the On this page list is not being rendered as a list. I'm pretty sure that's because there should be a blank line before the list. GitHub is more lenient about that.

https://azure.microsoft.com/en-us/documentation/samples/resource-manager-ruby-resources-and-groups/